### PR TITLE
rig plus minus button

### DIFF
--- a/calc-index1.html
+++ b/calc-index1.html
@@ -33,7 +33,7 @@
                 <!--row 1-->
                 <tr id="calc-top-row">
                     <td><input type="button" value="AC" class="special-btn" onclick="clearValues()" id="clearBtn"></td>
-                    <td><input type="button" value="±" class="special-btn"></td>
+                    <td><input type="button" value="±" class="special-btn" onclick="plusMinusFunc()" id="plusMinusBtn"></td>
                     <td><input type="button" value="%" class="special-btn" onclick="calculatePerc()" id="percentageBtn"></td>
                     <td><input type="button" value="÷" class="function-btn" onclick="divideValue()" id="divisionBtn"></td>
                 </tr>

--- a/scripts/calc1-scripts.js
+++ b/scripts/calc1-scripts.js
@@ -197,3 +197,14 @@ function calculatePerc() {
 
 // note that I'm not [yet] addressing weird functionality after the intial operations are completed. Ex. hitting percentage button more than once should result in nothing i think? but it just repeats (i wish the equals sign did that lol)
 
+// ---------------------------------- rigging plus/minus button. Hopefully simple replace value with '-'+value
+
+function plusMinusFunc() {
+    //let fieldValue1 = document.getElementById('text-field').value;
+    if (document.getElementById('text-field').value.includes('-') === false) {
+        document.getElementById('text-field').value = '-' + document.getElementById('text-field').value;
+    } else {
+        document.getElementById('text-field').value = document.getElementById('text-field').value.slice(1);
+    }
+}
+


### PR DESCRIPTION
used very redundant and lengthy syntax to add '-' when it's not there, and rid of '-' when it is there